### PR TITLE
Pin huggingface_hub and diffusers versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "draccus==0.8.0",
     "einops",
     # "flash_attn==2.5.5",      # Here for documentation -- install *AFTER* editable install (follow README)
-    "huggingface_hub",
+    "huggingface_hub==0.21.0",
     "json-numpy",
     "jsonlines",
     "matplotlib",
@@ -53,7 +53,7 @@ dependencies = [
     "tensorflow_datasets==4.9.3",
     "tensorflow_graphics==2021.12.3",
     "dlimp @ git+https://github.com/moojink/dlimp_openvla",
-    "diffusers",
+    "diffusers==0.27.2",
     "imageio",
     "uvicorn",
     "fastapi",


### PR DESCRIPTION
This prevents errors when running finetuning and evaluation. Newest `diffusers` requires `peft>=0.15.0` but `peft` is pinned in this repo. The `huggingface_hub` dependency has also removed `cached_download` in later versions. Selected earliest version of `huggingface_hub` that satisfies other dependencies.

An alternative option to help with reproducibility is to `pip freeze > requirements_frozen.txt` as a guide. It might also be worth mentioning which OS this was tested on (initially didn't work for me on 20.04 but did on 22.04).